### PR TITLE
Add exclude_hours and valid_hours attributes to cycledef

### DIFF
--- a/lib/workflowmgr/cycledef.rb
+++ b/lib/workflowmgr/cycledef.rb
@@ -639,7 +639,7 @@ module WorkflowMgr
     #
     ##########################################
     def hour_valid?(time)
-      hour = time.hour
+      hour = time.getgm.hour  # always use UTC hour
 
       if @valid_hours
         # Only valid_hours are valid

--- a/lib/workflowmgr/cycledef.rb
+++ b/lib/workflowmgr/cycledef.rb
@@ -561,16 +561,29 @@ module WorkflowMgr
 
     require 'workflowmgr/utilities'
 
+    attr_reader :exclude_hours, :valid_hours
+
     ##########################################
     #
     # initialize
     #
     ##########################################
-    def initialize(cycledef,group,activation_offset,position=nil)
+    def initialize(cycledef,group,activation_offset=0,position=nil,exclude_hours=nil,valid_hours=nil)
 
       @cycledef=cycledef
       @group=group
       @activation_offset=activation_offset
+
+      # Parse exclude_hours - hours to exclude from the cycle
+      @exclude_hours = parse_hours(exclude_hours)
+
+      # Parse valid_hours - only these hours are valid in the cycle
+      @valid_hours = parse_hours(valid_hours)
+
+      # Validate that exclude_hours and valid_hours are not both specified
+      if @exclude_hours && @valid_hours
+        raise "Invalid <cycledef>: Cannot specify both exclude_hours and valid_hours"
+      end
 
       fields=@cycledef.split
       @start=Time.gm(fields[0][0..3],
@@ -601,6 +614,48 @@ module WorkflowMgr
 
     ##########################################
     #
+    # parse_hours
+    #
+    ##########################################
+    def parse_hours(hours_str)
+      return nil if hours_str.nil? || hours_str.strip.empty?
+
+      hours = hours_str.strip.split.map(&:to_i)
+
+      # Validate that all hours are in the range 0-23
+      hours.each do |hour|
+        unless hour >= 0 && hour <= 23
+          raise "Invalid hour value '#{hour}' in cycledef. Hours must be in the range 0-23."
+        end
+      end
+
+      hours.uniq.sort
+    end
+
+
+    ##########################################
+    #
+    # hour_valid?
+    #
+    ##########################################
+    def hour_valid?(time)
+      hour = time.hour
+
+      if @valid_hours
+        # Only valid_hours are valid
+        return @valid_hours.include?(hour)
+      elsif @exclude_hours
+        # All hours except exclude_hours are valid
+        return !@exclude_hours.include?(hour)
+      else
+        # No filtering, all hours are valid
+        return true
+      end
+    end
+
+
+    ##########################################
+    #
     # next
     #
     ##########################################
@@ -616,16 +671,25 @@ module WorkflowMgr
       if reftime > @finish
         return nil
       elsif reftime <= @start
-        return @start.getgm,@start.getgm + @activation_offset
+        candidate = @start
       else
         offset=(reftime.to_i - @start.to_i) % @interval
         if offset==0
-          localnext=reftime
+          candidate=reftime
         else
-          localnext=Time.at(reftime - offset + @interval)
+          candidate=Time.at(reftime - offset + @interval)
         end
-        return localnext.getgm,localnext.getgm + @activation_offset
       end
+
+      # Apply hour filtering if exclude_hours or valid_hours is specified
+      while candidate <= @finish
+        if hour_valid?(candidate)
+          return candidate.getgm, candidate.getgm + @activation_offset
+        end
+        candidate = Time.at(candidate.to_i + @interval)
+      end
+
+      return nil
 
     end  # next
 
@@ -646,12 +710,21 @@ module WorkflowMgr
       if reftime < @start
         return nil
       elsif reftime >= @finish
-        return @finish,@finish + @activation_offset
+        candidate = @finish
       else
         offset=(reftime.to_i - @start.to_i) % @interval
-        localprev=Time.at(reftime - offset)
-        return localprev.getgm,localprev.getgm + @activation_offset
+        candidate=Time.at(reftime - offset)
       end
+
+      # Apply hour filtering if exclude_hours or valid_hours is specified
+      while candidate >= @start
+        if hour_valid?(candidate)
+          return candidate.getgm, candidate.getgm + @activation_offset
+        end
+        candidate = Time.at(candidate.to_i - @interval)
+      end
+
+      return nil
     end
 
     ##########################################
@@ -662,7 +735,10 @@ module WorkflowMgr
     def member?(reftime)
 
       return false if reftime < @start || reftime > @finish
-      return ((reftime.to_i - @start.to_i) % @interval) == 0
+      return false unless ((reftime.to_i - @start.to_i) % @interval) == 0
+
+      # Apply hour filtering
+      return hour_valid?(reftime)
 
     end
 

--- a/lib/workflowmgr/schema_with_metatasks.rng
+++ b/lib/workflowmgr/schema_with_metatasks.rng
@@ -98,6 +98,18 @@
                 <ref name="time"/>
               </attribute>
             </optional>
+            <!-- exclude_hours attribute: space-separated list of hours (0-23) to exclude -->
+            <optional>
+              <attribute name="exclude_hours">
+                <data type="string"/>
+              </attribute>
+            </optional>
+            <!-- valid_hours attribute: space-separated list of hours (0-23) to include (exclude all others) -->
+            <optional>
+              <attribute name="valid_hours">
+                <data type="string"/>
+              </attribute>
+            </optional>
             <choice>
               <list>
                 <ref name="cronField"/>

--- a/lib/workflowmgr/schema_without_metatasks.rng
+++ b/lib/workflowmgr/schema_without_metatasks.rng
@@ -98,6 +98,18 @@
                 <ref name="time"/>
 	      </attribute>
             </optional>
+            <!-- exclude_hours attribute: space-separated list of hours (0-23) to exclude -->
+            <optional>
+              <attribute name="exclude_hours">
+                <data type="string"/>
+              </attribute>
+            </optional>
+            <!-- valid_hours attribute: space-separated list of hours (0-23) to include (exclude all others) -->
+            <optional>
+              <attribute name="valid_hours">
+                <data type="string"/>
+              </attribute>
+            </optional>
             <choice>
               <list>
                 <ref name="cronField"/>

--- a/lib/workflowmgr/workflowdoc.rb
+++ b/lib/workflowmgr/workflowdoc.rb
@@ -314,6 +314,9 @@ module WorkflowMgr
         if nfields==3
           cycles << CycleInterval.new(cyclefields,group,activation_offset,nil,exclude_hours,valid_hours)
         elsif nfields==6
+          if exclude_hours || valid_hours
+            raise "ERROR: 'exclude_hours' or 'valid_hours' not supported in cron-style <cycledef>."
+          end
           cycles << CycleCron.new(cyclefields,group,activation_offset)
         else
           raise "ERROR: Unsupported <cycle> type!"

--- a/lib/workflowmgr/workflowdoc.rb
+++ b/lib/workflowmgr/workflowdoc.rb
@@ -309,8 +309,10 @@ module WorkflowMgr
         else
           activation_offset=0
         end
+        exclude_hours=cyclenode.attributes['exclude_hours']
+        valid_hours=cyclenode.attributes['valid_hours']
         if nfields==3
-          cycles << CycleInterval.new(cyclefields,group,activation_offset)
+          cycles << CycleInterval.new(cyclefields,group,activation_offset,nil,exclude_hours,valid_hours)
         elsif nfields==6
           cycles << CycleCron.new(cyclefields,group,activation_offset)
         else

--- a/test/test_cycledef.rb
+++ b/test/test_cycledef.rb
@@ -399,4 +399,107 @@ specific year\n   12Z, every day of June, July, August of 2010")
 
   end
 
+
+  # Tests for exclude_hours attribute
+  def test_cycleinterval_exclude_hours
+
+    # Create a 6-hourly cycle (00, 06, 12, 18) but exclude hours 6 and 18
+    cycle1=WorkflowMgr::CycleInterval.new("201101010000 201101012300 06:00:00","test",0,nil,"6 18")
+
+    # Test next - should skip hour 6 and go to hour 12
+    cycle2=cycle1.next(Time.gm(2011,1,1,0,0))
+    assert_equal(Time.gm(2011,1,1,0,0),cycle2[0], message="Hour 0 should be valid with exclude_hours='6 18'")
+
+    cycle2=cycle1.next(Time.gm(2011,1,1,0,1))
+    assert_equal(Time.gm(2011,1,1,12,0),cycle2[0], message="Next after 0 should skip hour 6 and go to 12")
+
+    cycle2=cycle1.next(Time.gm(2011,1,1,12,1))
+    assert_equal(Time.gm(2011,1,2,0,0),cycle2[0], message="Next after 12 should skip hour 18 and go to next day 0")
+
+    # Test previous
+    cycle2=cycle1.previous(Time.gm(2011,1,1,18,0))
+    assert_equal(Time.gm(2011,1,1,12,0),cycle2[0], message="Previous from 18 should be 12 since 18 is excluded")
+
+    cycle2=cycle1.previous(Time.gm(2011,1,1,12,0))
+    assert_equal(Time.gm(2011,1,1,12,0),cycle2[0], message="Previous from 12 should be 12")
+
+    cycle2=cycle1.previous(Time.gm(2011,1,1,6,0))
+    assert_equal(Time.gm(2011,1,1,0,0),cycle2[0], message="Previous from 6 should be 0 since 6 is excluded")
+
+    # Test member?
+    assert_equal(true,cycle1.member?(Time.gm(2011,1,1,0,0)), message="Hour 0 should be a member")
+    assert_equal(false,cycle1.member?(Time.gm(2011,1,1,6,0)), message="Hour 6 should NOT be a member (excluded)")
+    assert_equal(true,cycle1.member?(Time.gm(2011,1,1,12,0)), message="Hour 12 should be a member")
+    assert_equal(false,cycle1.member?(Time.gm(2011,1,1,18,0)), message="Hour 18 should NOT be a member (excluded)")
+
+    # Test first and last
+    assert_equal(Time.gm(2011,1,1,0,0),cycle1.first, message="First should be hour 0")
+
+  end
+
+
+  # Tests for valid_hours attribute
+  def test_cycleinterval_valid_hours
+
+    # Create an hourly cycle but only keep hours 3, 9, 15
+    cycle1=WorkflowMgr::CycleInterval.new("201101010000 201101012300 01:00:00","test",0,nil,nil,"3 9 15")
+
+    # Test next - from hour 0, should go to hour 3
+    cycle2=cycle1.next(Time.gm(2011,1,1,0,0))
+    assert_equal(Time.gm(2011,1,1,3,0),cycle2[0], message="First valid hour from 0 should be 3")
+
+    cycle2=cycle1.next(Time.gm(2011,1,1,3,1))
+    assert_equal(Time.gm(2011,1,1,9,0),cycle2[0], message="Next after 3 should be 9")
+
+    cycle2=cycle1.next(Time.gm(2011,1,1,9,1))
+    assert_equal(Time.gm(2011,1,1,15,0),cycle2[0], message="Next after 9 should be 15")
+
+    cycle2=cycle1.next(Time.gm(2011,1,1,15,1))
+    assert_equal(Time.gm(2011,1,2,3,0),cycle2[0], message="Next after 15 should be 3 on next day")
+
+    # Test previous
+    cycle2=cycle1.previous(Time.gm(2011,1,1,16,0))
+    assert_equal(Time.gm(2011,1,1,15,0),cycle2[0], message="Previous from 16 should be 15")
+
+    cycle2=cycle1.previous(Time.gm(2011,1,1,15,0))
+    assert_equal(Time.gm(2011,1,1,15,0),cycle2[0], message="Previous from 15 should be 15")
+
+    cycle2=cycle1.previous(Time.gm(2011,1,1,14,0))
+    assert_equal(Time.gm(2011,1,1,9,0),cycle2[0], message="Previous from 14 should be 9")
+
+    # Test member?
+    assert_equal(false,cycle1.member?(Time.gm(2011,1,1,0,0)), message="Hour 0 should NOT be a member")
+    assert_equal(true,cycle1.member?(Time.gm(2011,1,1,3,0)), message="Hour 3 should be a member")
+    assert_equal(false,cycle1.member?(Time.gm(2011,1,1,6,0)), message="Hour 6 should NOT be a member")
+    assert_equal(true,cycle1.member?(Time.gm(2011,1,1,9,0)), message="Hour 9 should be a member")
+    assert_equal(false,cycle1.member?(Time.gm(2011,1,1,12,0)), message="Hour 12 should NOT be a member")
+    assert_equal(true,cycle1.member?(Time.gm(2011,1,1,15,0)), message="Hour 15 should be a member")
+
+    # Test first
+    assert_equal(Time.gm(2011,1,1,3,0),cycle1.first, message="First should be hour 3")
+
+  end
+
+
+  # Test that both exclude_hours and valid_hours raises an error
+  def test_cycleinterval_both_exclude_and_valid_hours_error
+    assert_raise(RuntimeError) {
+      WorkflowMgr::CycleInterval.new("201101010000 201101012300 01:00:00","test",0,nil,"6 18","3 9 15")
+    }
+  end
+
+
+  # Test invalid hour values
+  def test_cycleinterval_invalid_hour_values
+    assert_raise(RuntimeError) {
+      WorkflowMgr::CycleInterval.new("201101010000 201101012300 01:00:00","test",0,nil,"25")
+    }
+    assert_raise(RuntimeError) {
+      WorkflowMgr::CycleInterval.new("201101010000 201101012300 01:00:00","test",0,nil,nil,"30")
+    }
+    assert_raise(RuntimeError) {
+      WorkflowMgr::CycleInterval.new("201101010000 201101012300 01:00:00","test",0,nil,"-1")
+    }
+  end
+
 end


### PR DESCRIPTION
Add exclude_hours and valid_hours attributes to cycledef
- exclude_hours: removes specified hours from expanded cycles
- valid_hours: keeps only specified hours in expanded cycles
- Updated CycleInterval class with hour filtering in next/previous/member?
- Updated XML schemas and workflowdoc.rb parser
- Added unit tests for new functionality

Example usage:
```
<cycledef exclude_hours="3 4 5 6">201101010000 201112311800 06:00:00</cycledef>
<cycledef valid_hours="0 6 12 18">201101010000 201112312300 01:00:00</cycledef>
```

### solved problem:
This PR  address the complexity in the specification of the following types of cycles:
For example, during the retro period `2024122712-2025021012`, we need to run a task only at `03-08` and `15-20` cycles each day. Currently, we need to use 5 different `cycledef` to correctly represent this situation:
```
<cycledef group="spinup0">00 15-20 27 12 2024 *</cycledef>
<cycledef group="spinup1">00 03-08,15-20 28-31 12 2024 *</cycledef>
<cycledef group="spinup2">00 03-08,15-20 01-31 01 2025 *</cycledef>
<cycledef group="spinup3">00 03-08,15-20 01-09 02 2025 *</cycledef>
<cycledef group="spinup4">00 03-08 10 02 2025 *</cycledef>
```
With this PR we can simplify the above 5 `cycledef` into one:
```
<cycledef group="spinup" valid_hours="3 4 5 6 7 8 15 16 17 18 19 20">202412271200 202502101200 01:00:00</cycledef>
```
This significantly simplifies our workflow logic.