### PR TITLE
Add a '--harvest-only' option to allow rocotorun to only harvest

### DIFF
--- a/lib/workflowmgr/workflowengine.rb
+++ b/lib/workflowmgr/workflowengine.rb
@@ -257,8 +257,8 @@ module WorkflowMgr
         # Get the active cycles
         load_active_cycles
 
-        # Get new cycles that need to be activated now
-        fetch_new_cycles
+        # Get new cycles that need to be activated now, unless in the harvest_only mode
+        fetch_new_cycles unless @options.harvest_only
 
         # Get the active jobs, which may include jobs from cycles that have just expired
         # as well as jobs needed for evaluating inter cycle dependencies
@@ -270,11 +270,11 @@ module WorkflowMgr
         # Deactivate completed cycles
         deactivate_done_cycles
 
-        # Expire active cycles that have exceeded the cycle life span
-        expire_cycles
+        # Expire active cycles that have exceeded the cycle life span, unless in the harvest_only mode
+        expire_cycles unless @options.harvest_only
 
-        # Submit new tasks where possible
-        submit_new_jobs
+        # Submit new tasks where possible, unless in the harvest_only mode
+        submit_new_jobs unless @options.harvest_only
 
         # Auto vacuum if necessary, but only for realtime mode
         auto_vacuum if @config.AutoVacuum && @realtime
@@ -1408,7 +1408,8 @@ module WorkflowMgr
           end
 
           # Can't check for hangs/expiration for jobs whose task is no longer defined
-          unless @tasks[job.task].nil?
+          #   nor in the harvest-only mode
+          unless @tasks[job.task].nil? || @options.harvest_only
 
             # Check for job hang
             if !@tasks[job.task].hangdependency.nil? && (job.state == "RUNNING")

--- a/lib/workflowmgr/workflowsubsetoptions.rb
+++ b/lib/workflowmgr/workflowsubsetoptions.rb
@@ -15,7 +15,7 @@ module WorkflowMgr
   class WorkflowSubsetOptions < WorkflowOption
     require 'workflowmgr/workflowselection'
 
-    attr_reader :database, :workflowdoc, :cycles, :tasks, :metatasks, :verbose
+    attr_reader :database, :workflowdoc, :cycles, :tasks, :metatasks, :verbose, :harvest_only
 
     ##########################################
     #
@@ -30,6 +30,7 @@ module WorkflowMgr
       @action = action # ie.: boot
       @all_tasks = false
       @all_cycles = false
+      @harvest_only = false
       @selection = nil
       super(args)
     end
@@ -100,6 +101,13 @@ module WorkflowMgr
       # Rewind all tasks for the specified cycles instead of a list of tasks:
       opts.on("-a", '--all', "Selects all tasks.") do |flag|
         @all_tasks = true
+      end
+
+      # Harvest without making any changes to the batch system (rocotorun only)
+      if @name == 'rocotorun'
+        opts.on("--harvest-only", "Harvest pending submissions without making any changes to the batch system") do
+          @harvest_only = true
+        end
       end
     end
 

--- a/man/man1/rocotorun.1
+++ b/man/man1/rocotorun.1
@@ -13,6 +13,7 @@
 .Op Fl h
 .Op Fl v Ar #
 .Op Fl -version
+.Op Fl -harvest-only
 .Fl d Ar database_file
 .Fl w Ar workflow_file
 .Sh DESCRIPTION
@@ -61,6 +62,8 @@ Only submit jobs for these tasks.  See
 .It Fl a, --all
 Include all tasks in the workflow subset.  See
 .Sx WORKFLOW SUBSETTING
+.It Fl -harvest-only
+Harvest the pending submissions without making any changes to the batch system.
 .El
 .Sh WORKFLOW SUBSETTING
 All Rocoto commands that monitor or modify the workflow can be told to


### PR DESCRIPTION
Gaea provides only scrontab and no crontab. Similar to issue #112 , we found that dead jobs occurred quite often due to errors such as: 
```
.... the server process at druby://gaea61.ncrc.gov:36461 died
....Submission....probably, but not necessarily, failed.  It will be resubmitted
```

Upon investigation, it  was found that `rocotorun` spawned daemon servers helping with actual job submissions, allowing itself to respond quickly without potentially hanging when a job submission takes too long.

However, not all daemon servers necessarily return their results before `rocotorun` completes.
When a scrontab job (executing rocotorun) exits from the job scheduler, all process in its cgroup, including the daemon servers, are killed.  As a result, the next `rocotorun` invocation can never harvest pending job submissions and hence unexpectedly resubmit the same tasks.

This PR attempts to address this issue by adding a `--harvest-only` option to `rocotorun`. 
With this option, in scrontab, we can first rocotorun to submit jobs, sleep a few seconds,  and then `rocotorun --harvest-only` to harvest pending submissions before the scrontab job exits.

I have tested this on Gaea and it resolve the issue above.
